### PR TITLE
[docker] Running blockstack-cli and node-red flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+blockstack/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,34 @@
-FROM nodered/node-red-docker
+FROM ubuntu:16.04
 
+# Install node.js
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+RUN apt-get install -y nodejs
+
+# Home directory for Node-RED application source code.
+RUN mkdir -p /usr/src/node-red
+
+# User data directory, contains flows, config and nodes.
+RUN mkdir /data
+WORKDIR /usr/src/node-red
+
+# package.json contains Node-RED NPM module and node dependencies
+COPY node-red/package.json /usr/src/node-red/
+RUN npm install
+
+# User configuration directory volume
+EXPOSE 1880
+
+# Environment variable holding file path for flows configuration
+ENV FLOWS=flows.json
+
+# Install packages
 RUN npm install node-red-contrib-redis node-red-contrib-auth
+
+# Install blockstack
+RUN apt-get update && apt-get install -y python-pip python-dev libssl-dev libffi-dev rng-tools
+
+RUN pip install --upgrade pip && pip install blockstack
+
+CMD ["npm", "start", "--", "--userDir", "/data"]
+

--- a/node-red/.config.json
+++ b/node-red/.config.json
@@ -371,7 +371,7 @@
   },
   "node-red-node-email": {
    "name": "node-red-node-email",
-   "version": "0.1.15",
+   "version": "0.1.21",
    "local": false,
    "nodes": {
     "email": {

--- a/node-red/package.json
+++ b/node-red/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "node-red-docker",
+    "version": "0.16.2",
+    "description": "A visual tool for wiring the Internet of Things",
+    "homepage": "http://nodered.org",
+    "license": "Apache 2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/node-red/node-red-docker.git"
+    },
+    "main": "node_modules/node-red/red/red.js",
+    "scripts": {
+        "start": "node $NODE_OPTIONS node_modules/node-red/red.js -v $FLOWS"
+    },
+    "contributors": [
+        {
+            "name": "Dave Conway-Jones"
+        },
+        {
+            "name": "Nick O'Leary"
+        },
+        {
+            "name": "James Thomas"
+        }
+    ],
+    "dependencies": {
+        "node-red": "0.16.2",
+        "node-red-node-msgpack": "*",
+        "node-red-node-base64": "*",
+        "node-red-node-suncalc": "*",
+        "node-red-node-random": "*"
+    },
+    "engines": {
+        "node": "4.*.*"
+    }
+}

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-docker build -t gcr.io/jackzampolin-web/cryptocracy:latest .
-docker run -d -p 1880:1880 -v $(pwd)/node-red:/data -v $(pwd)/blockstack:/root/.blockstack/ --name cryptocracy gcr.io/jackzampolin-web/cryptocracy:latest
+PROJECT=cryptocracy
+
+docker build -t gcr.io/$PROJECT/cryptocracy:latest .
+docker run -d -p 1880:1880 -v $(pwd)/node-red:/data -v $(pwd)/blockstack:/root/.blockstack/ --name cryptocracy gcr.io/$PROJECT/cryptocracy:latest
 docker exec -it cryptocracy /bin/bash

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 docker build -t gcr.io/jackzampolin-web/cryptocracy:latest .
-docker run -it -p 1880:1880 -v $(pwd)/node-red:/data --name cryptocracy gcr.io/jackzampolin-web/cryptocracy:latest
+docker run -d -p 1880:1880 -v $(pwd)/node-red:/data -v $(pwd)/blockstack:/root/.blockstack/ --name cryptocracy gcr.io/jackzampolin-web/cryptocracy:latest
+docker exec -it cryptocracy /bin/bash


### PR DESCRIPTION
This PR has a running `flows` server with access to a functional `blockstack` cli. 

To run, have a working [docker installation](https://docs.docker.com/engine/installation/):

```
$ cd flows
$ ./run.sh
```

This will build the docker container with `node-red` and `blockstack` properly configured, and spin up an instance of it. You will be placed into a command prompt. Run `blockstack info` to generate a wallet and then exit the terminal window. You should be able to visit `node-red` at `localhost:1880`.

### Notes
* In the container the `/data` directory for `node-red` is persisted in the root of this project in the `node-red/` directory.
* In the container the `~/.blockstack` directory is persisted in the `blockstack/` directory in the root of the folder. This is because we create the container with two volumes during the `docker run` command.
* Currently, using preexisting wallet is untested.

This setup currently spins up only the api server. When you have the redis flows loaded in `node-red/flows.json` I will add the redis container and do the networking. 